### PR TITLE
feat: support concat operator

### DIFF
--- a/lib/net/url.lua
+++ b/lib/net/url.lua
@@ -84,6 +84,10 @@ local function encodeSegment(s)
 	return s:gsub('([^a-zA-Z0-9])', legalEncode)
 end
 
+local function concat(s, u)
+	return s .. u:build()
+end
+
 --- builds the url
 -- @return a string representing the built url
 function M:build()
@@ -309,6 +313,7 @@ function M.parse(url)
 
 	setmetatable(comp, {
 		__index = M,
+		__concat = concat,
 		__tostring = M.build}
 	)
 	return comp


### PR DESCRIPTION
Using `..` with a parsed url will call its `build` method before concatenating.

Previously, it would throw an exception:
```
lua: ./src/init.lua:22: attempt to concatenate a table value (local 'u')
stack traceback:
	./src/init.lua:22: in main chunk
	[C]: in function 'require'
	init.lua:7: in main chunk
	[C]: in ?
```