### PR TITLE
Correctly handle plus sign

### DIFF
--- a/lib/net/url.lua
+++ b/lib/net/url.lua
@@ -55,8 +55,11 @@ local legal = {
 	[";"] = true -- can be used for parameters in path
 }
 
-local function decode(str)
-	local str = str:gsub('+', ' ')
+local function decode(str, path)
+	local str = str
+	if not path then
+		str = str:gsub('+', ' ')
+	end
 	return (str:gsub("%%(%x%x)", function(c)
 			return string.char(tonumber(c, 16))
 	end))
@@ -305,7 +308,7 @@ function M.parse(url)
 		M.setAuthority(comp, v)
 		return ''
 	end)
-	comp.path = decode(url)
+	comp.path = decode(url, true)
 
 	setmetatable(comp, {
 		__index = M,

--- a/tests/url_test.lua
+++ b/tests/url_test.lua
@@ -122,6 +122,7 @@ local test2 = {
 	["http://www.foo.com/%7ebar"] = "http://www.foo.com/~bar",
 	["http://www.foo.com/%7Ebar"] = "http://www.foo.com/~bar",
 	["http://www.foo.com/?p=529&#038;cpage=1#comment-783"] = "http://www.foo.com/?p=529#038;cpage=1#comment-783",
+	["http://www.foo.com/some +path/?args=foo%2Bbar"] = "http://www.foo.com/some +path/?args=foo+bar",
 	["/foo/bar/../../../baz"] = "/baz",
 	["/foo/bar/../../../../baz"] = "/baz",
 	["/./../foo"] = "/foo",


### PR DESCRIPTION
Hi!
I made changes to correctly handle plus sign, but I didn't run tests yet. Similar change is working in my application (which is tested for this case), so I open this PR.

Please run the tests if you have some time and I'll try to prepare some environment (probably Dockerfile) to run those tests without installing all stuff on local machine.

*Current behaviour*:
Library replaces plus sign with space everywhere in URL

*Expected behaviour*:
Spaces in path part of URL are untouched, we only replace it in query part.