### PR TITLE
Fixed white space being returned in urls

### DIFF
--- a/lib/net/url.lua
+++ b/lib/net/url.lua
@@ -97,7 +97,7 @@ function M:build()
 	local url = ''
 	if self.path then
 		local path = self.path
-		path:gsub("([^/]+)", function (s) return encodeSegment(s) end)
+		path = path:gsub("([^/]+)", function (s) return encodeSegment(s) end)
 		url = url .. tostring(path)
 	end
 	if self.query then


### PR DESCRIPTION
Fixes #10

Explanation:
In Lua strings are never passed by reference therefore they are recreated and the original is never changed. You need to override the original with the new string. The escape function was run but its result was not used. This change fixes the escape call on the path and the result of the tostring/build operation is correctly escaped now.